### PR TITLE
Creating client-related sub-entities should return ids and not bool.

### DIFF
--- a/src/Keycloak.Net.Core/AuthorizationResource/KeycloakClient.cs
+++ b/src/Keycloak.Net.Core/AuthorizationResource/KeycloakClient.cs
@@ -8,13 +8,14 @@ namespace Keycloak.Net
 {
     public partial class KeycloakClient
     {
-        public async Task<bool> CreateResourceAsync(string realm, string resourceServerId, AuthorizationResource resource, CancellationToken cancellationToken = default)
+        public async Task<string> CreateResourceAsync(string realm, string resourceServerId, AuthorizationResource resource, CancellationToken cancellationToken = default)
         {
             var response = await GetBaseUrl(realm)
                 .AppendPathSegment($"/admin/realms/{realm}/clients/{resourceServerId}/authz/resource-server/resource")
                 .PostJsonAsync(resource, cancellationToken)
+                .ReceiveJson<AuthorizationResource>()
                 .ConfigureAwait(false);
-            return response.ResponseMessage.IsSuccessStatusCode;
+            return response.Id;
         }
 
         public async Task<IEnumerable<AuthorizationResource>> GetResourcesAsync(string realm, string resourceServerId = null,

--- a/src/Keycloak.Net.Core/AuthorizationScope/KeycloakClient.cs
+++ b/src/Keycloak.Net.Core/AuthorizationScope/KeycloakClient.cs
@@ -8,13 +8,14 @@ namespace Keycloak.Net
 {
     public partial class KeycloakClient
     {
-        public async Task<bool> CreateAuthorizationScopeAsync(string realm, string resourceServerId, AuthorizationScope scope, CancellationToken cancellationToken = default)
+        public async Task<string> CreateAuthorizationScopeAsync(string realm, string resourceServerId, AuthorizationScope scope, CancellationToken cancellationToken = default)
         {
             var response = await GetBaseUrl(realm)
                 .AppendPathSegment($"/admin/realms/{realm}/clients/{resourceServerId}/authz/resource-server/scope")
                 .PostJsonAsync(scope, cancellationToken)
+                .ReceiveJson<AuthorizationScope>()
                 .ConfigureAwait(false);
-            return response.ResponseMessage.IsSuccessStatusCode;
+            return response.Id;
         }
 
         public async Task<IEnumerable<AuthorizationScope>> GetAuthorizationScopesAsync(string realm, string resourceServerId = null,

--- a/src/Keycloak.Net.Core/ClientAuthorization/KeycloakClient.cs
+++ b/src/Keycloak.Net.Core/ClientAuthorization/KeycloakClient.cs
@@ -127,7 +127,7 @@ namespace Keycloak.Net
         {
             var response = await GetBaseUrl(realm)
                 .AppendPathSegment($"/admin/realms/{realm}/clients/{clientId}/authz/resource-server/policy")
-                .AppendPathSegment(policy.Type == PolicyType.User ? "/group" : string.Empty)
+                .AppendPathSegment(policy.Type == PolicyType.Group ? "/group" : string.Empty)
                 .PostJsonAsync(policy, cancellationToken)
                 .ReceiveJson<GroupPolicy>()
                 .ConfigureAwait(false);

--- a/src/Keycloak.Net.Core/Models/Clients/RolePolicy.cs
+++ b/src/Keycloak.Net.Core/Models/Clients/RolePolicy.cs
@@ -120,6 +120,9 @@ namespace Keycloak.Net.Models.Clients
 
         [JsonProperty("path")]
         public string Path { get; set; }
+
+        [JsonProperty("extendChildren")]
+        public bool ExtendChildren { get; set; }
     }
 
     public enum PolicyType


### PR DESCRIPTION
Having non 200 status will throw exception from insides of Flurl, no need to return this stuff, but ids are needed for others related methods (for creating permissions for example).
Also corrected bug that creation of group policy was not getting sub-route properly applied.