### PR TITLE
add GetGroupChildrenAsync to KeycloakClient

### DIFF
--- a/src/Keycloak.Net.Core/Groups/KeycloakClient.cs
+++ b/src/Keycloak.Net.Core/Groups/KeycloakClient.cs
@@ -92,10 +92,18 @@ namespace Keycloak.Net
             return response.ResponseMessage.IsSuccessStatusCode;
         }
 
-        public async Task<IEnumerable<Group>> GetGroupChildrenAsync(string realm, string groupId, CancellationToken cancellationToken = default)
+        public async Task<IEnumerable<Group>> GetGroupChildrenAsync(string realm, string groupId, int? first = null, int? max = null, CancellationToken cancellationToken = default)
         {
+            var queryParams = new Dictionary<string, object>
+            {
+                [nameof(first)] = first,
+                [nameof(max)] = max,
+                ["briefRepresentation"] = false
+            };
+
             var result = await GetBaseUrl(realm)
                 .AppendPathSegment($"/admin/realms/{realm}/groups/{groupId}/children")
+                .SetQueryParams(queryParams)
                 .GetJsonAsync<IEnumerable<Group>>(cancellationToken)
                 .ConfigureAwait(false);
             

--- a/src/Keycloak.Net.Core/Groups/KeycloakClient.cs
+++ b/src/Keycloak.Net.Core/Groups/KeycloakClient.cs
@@ -92,6 +92,16 @@ namespace Keycloak.Net
             return response.ResponseMessage.IsSuccessStatusCode;
         }
 
+        public async Task<IEnumerable<Group>> GetGroupChildrenAsync(string realm, string groupId, CancellationToken cancellationToken = default)
+        {
+            var result = await GetBaseUrl(realm)
+                .AppendPathSegment($"/admin/realms/{realm}/groups/{groupId}/children")
+                .GetJsonAsync<IEnumerable<Group>>(cancellationToken)
+                .ConfigureAwait(false);
+            
+            return result;
+        }
+
         public async Task<ManagementPermission> GetGroupClientAuthorizationPermissionsInitializedAsync(string realm, string groupId, CancellationToken cancellationToken = default) => await GetBaseUrl(realm)
             .AppendPathSegment($"/admin/realms/{realm}/groups/{groupId}/management/permissions")
             .GetJsonAsync<ManagementPermission>(cancellationToken)


### PR DESCRIPTION
Adding this for:

`GET /admin/realms/{realm}/groups/{group-id}/children`

in order to fetch children in the same way the web UI does it. https://www.keycloak.org/docs-api/24.0.2/rest-api/index.html#_get_adminrealmsrealmgroupsgroup_idchildren

this guy gives me the top level groups but doesn't populate `subGroups`:

`GET /admin/realms/{realm}/groups
`
this guy doesn't populate the `subGroups` of a single group:

`GET /admin/realms/{realm}/groups/{group-id}
`
tested with Keycloak version 23.0.4