### PR TITLE
fix: added filtering for GetUsersCountAsync

### DIFF
--- a/src/Keycloak.Net.Core/Users/KeycloakClient.cs
+++ b/src/Keycloak.Net.Core/Users/KeycloakClient.cs
@@ -60,10 +60,27 @@ namespace Keycloak.Net
                 .ConfigureAwait(false);
         }
 
-        public async Task<int> GetUsersCountAsync(string realm, CancellationToken cancellationToken = default) => await GetBaseUrl(realm)
-            .AppendPathSegment($"/admin/realms/{realm}/users/count")
-            .GetJsonAsync<int>(cancellationToken)
-            .ConfigureAwait(false);
+        public async Task<int> GetUsersCountAsync(string realm, string email = null, bool? emailVerified = null, bool? enabled = null,
+            string firstName = null, string lastName = null, string q = null, string search = null, string username = null, CancellationToken cancellationToken = default)
+        {
+            var queryParams = new Dictionary<string, object>
+            {
+                [nameof(email)] = email,
+                [nameof(emailVerified)] = emailVerified,
+                [nameof(enabled)] = enabled,
+                [nameof(firstName)] = firstName,
+                [nameof(lastName)] = lastName,
+                [nameof(q)] = q,
+                [nameof(search)] = search,
+                [nameof(username)] = username,
+            };
+
+            return await GetBaseUrl(realm)
+                .AppendPathSegment($"/admin/realms/{realm}/users/count")
+                .SetQueryParams(queryParams)
+                .GetJsonAsync<int>(cancellationToken)
+                .ConfigureAwait(false);
+        }
 
         public async Task<User> GetUserAsync(string realm, string userId, CancellationToken cancellationToken = default) => await GetBaseUrl(realm)
             .AppendPathSegment($"/admin/realms/{realm}/users/{userId}")


### PR DESCRIPTION
Enhanced the GetUsersCountAsync to include the filtering as documented here: https://www.keycloak.org/docs-api/22.0.1/rest-api/index.html#_users:~:text=GET%20/admin/realms/%7Brealm%7D/users/count