### PR TITLE
Added token exchange functionalities

### DIFF
--- a/src/Keycloak.Net.Core/Clients/KeycloakClient.cs
+++ b/src/Keycloak.Net.Core/Clients/KeycloakClient.cs
@@ -1,4 +1,5 @@
-﻿using Keycloak.Net.Models.Clients;
+﻿using Keycloak.Net.Core.Models.Root;
+using Keycloak.Net.Models.Clients;
 using Keycloak.Net.Models.ClientScopes;
 using Keycloak.Net.Models.Common;
 using Keycloak.Net.Models.Roles;
@@ -371,4 +372,49 @@ public partial class KeycloakClient
 													cancellationToken: cancellationToken)
 							   .ReceiveJson<IEnumerable<Resource>>()
 							   .ConfigureAwait(false);
+
+    public async Task<Token> GetTokenExchangeResponseAsync(string realm,
+                                                           string clientId,
+                                                           string userId,
+                                                           string clientSecret,
+                                                           CancellationToken cancellationToken = default)
+    {
+        var parameters = new Dictionary<string, string>
+		{
+			{ "grant_type", "urn:ietf:params:oauth:grant-type:token-exchange" },
+			{ "client_id", clientId },
+			{ "client_secret", clientSecret },
+			{ "requested_subject", userId },
+			{ "scope", "openid" }
+		};
+
+        return await GetBaseUrl(realm)
+            .AppendPathSegment($"/realms/{realm}/protocol/openid-connect/token")
+            .PostUrlEncodedAsync(parameters, cancellationToken: cancellationToken)
+            .ReceiveJson<Token>()
+            .ConfigureAwait(false);
+    }
+
+    public async Task<Token> GetTokenWithResourceOwnerPasswordCredentialsAsync(string realm,
+																			   string clientId,
+																			   string username,
+																			   string password,
+																			   string clientSecret,
+																			   CancellationToken cancellationToken = default)
+    {
+        var parameters = new Dictionary<string, string>
+		{
+			{ "grant_type", "password" },
+			{ "client_id", clientId },
+			{ "client_secret", clientSecret },
+			{ "username", username },
+			{ "password", password }
+		};
+
+        return await GetBaseUrl(realm)
+            .AppendPathSegment($"/realms/{realm}/protocol/openid-connect/token")
+            .PostUrlEncodedAsync(parameters, cancellationToken: cancellationToken)
+            .ReceiveJson<Token>()
+            .ConfigureAwait(false);
+    }
 }

--- a/src/Keycloak.Net.Core/Models/Root/Token.cs
+++ b/src/Keycloak.Net.Core/Models/Root/Token.cs
@@ -1,0 +1,34 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Keycloak.Net.Core.Models.Root;
+
+public class Token
+{
+    [JsonPropertyName("access_token")]
+    public string AccessToken { get; set; }
+
+    [JsonPropertyName("expires_in")]
+    public int ExpiresIn { get; set; }
+
+    [JsonPropertyName("refresh_expires_in")]
+    public int RefreshExpiresIn { get; set; }
+
+    [JsonPropertyName("refresh_token")]
+    public string RefreshToken { get; set; }
+
+    [JsonPropertyName("token_type")]
+    public string TokenType { get; set; }
+
+    [JsonPropertyName("id_token")]
+    public string IdToken { get; set; }
+
+    [JsonPropertyName("not-before-policy")]
+    public int NotBeforePolicy { get; set; }
+
+    [JsonPropertyName("session_state")]
+    public string SessionState { get; set; }
+
+    [JsonPropertyName("scope")]
+    public string Scope { get; set; }
+}
+


### PR DESCRIPTION
# Implementing User Impersonation via Token Exchange in Keycloak.Net

This introduces the implementation of user impersonation in the Keycloak.Net library using the OAuth 2.0 Token Exchange grant type. The implementation aligns with Keycloak's token exchange capabilities, allowing clients to exchange tokens on behalf of users.

## Background

User impersonation is a common requirement in applications where administrators or service accounts need to perform actions on behalf of other users. Keycloak supports this functionality through the OAuth 2.0 Token Exchange specification.

Implementing token exchange in Keycloak.Net enables developers to programmatically exchange tokens, facilitating operations like impersonation and delegation within applications using Keycloak for authentication and authorization.

## Keycloak Configuration for Token Exchange

Before using the token exchange features, specific configurations are required in Keycloak:

1. **Enable Preview Features**: Token Exchange is considered a preview feature in Keycloak and must be enabled.

   - Set the following environment variables or JVM options when starting Keycloak:

     ```bash
     -Dkeycloak.profile=preview
     -Dkeycloak.profile.feature.token_exchange=enabled
     ```

   - In a Docker environment, update the `docker-compose.yml`:

     ```yaml
     environment:
       - JAVA_OPTS_APPEND=-Dkeycloak.profile=preview -Dkeycloak.profile.feature.token_exchange=enabled
     ```

2. **Assign the `impersonation` Role to the Client**:

   - Navigate to **Clients** > **realm-management** > **Roles**.
   - Select the `impersonation` role.
   - Click on **Add Assignment** and assign it to the client that will perform the impersonation.

3. **Configure Token Exchange Permissions**:

   - Go to **Clients** > **realm-management** > **Authorization** > **Policies**.
   - Create a new client policy that includes your client.
   - Under **Permissions**, ensure that the policy is associated with the appropriate permissions.

## Implementation in Keycloak.Net

### Adding the `Token` Model

A new model class `Token` has been added to `/Models/Root` to represent the token response from Keycloak's token endpoint. It is possible that this class name is a bit generic, please feel free to recommend a better name.

```csharp
using System.Text.Json.Serialization;

namespace Keycloak.Net.Core.Models.Root;

public class Token
{
    [JsonPropertyName("access_token")]
    public string AccessToken { get; set; }

    [JsonPropertyName("expires_in")]
    public int ExpiresIn { get; set; }

    [JsonPropertyName("refresh_expires_in")]
    public int RefreshExpiresIn { get; set; }

    [JsonPropertyName("refresh_token")]
    public string RefreshToken { get; set; }

    [JsonPropertyName("token_type")]
    public string TokenType { get; set; }

    [JsonPropertyName("id_token")]
    public string IdToken { get; set; }

    [JsonPropertyName("not-before-policy")]
    public int NotBeforePolicy { get; set; }

    [JsonPropertyName("session_state")]
    public string SessionState { get; set; }

    [JsonPropertyName("scope")]
    public string Scope { get; set; }
}
```

### Implementing Token Exchange Methods

Two new methods have been added to the `/Clients/KeycloakClient.cs` class:

1. **Token Exchange (Impersonation)**

   ```csharp
   public async Task<Token> GetTokenExchangeResponseAsync(string realm,
                                                          string clientId,
                                                          string userId,
                                                          string clientSecret,
                                                          CancellationToken cancellationToken = default)
   {
       var parameters = new Dictionary<string, string>
       {
           { "grant_type", "urn:ietf:params:oauth:grant-type:token-exchange" },
           { "client_id", clientId },
           { "client_secret", clientSecret },
           { "requested_subject", userId },
           { "scope", "openid" }
       };

       return await GetBaseUrl(realm)
           .AppendPathSegment($"/realms/{realm}/protocol/openid-connect/token")
           .PostUrlEncodedAsync(parameters, cancellationToken: cancellationToken)
           .ReceiveJson<Token>()
           .ConfigureAwait(false);
   }
   ```

   **Explanation:**

   - The method constructs a token exchange request to impersonate a user.
   - `requested_subject` is the user ID of the user to impersonate.
   - `client_id` and `client_secret` authenticate the client.
   - The response is deserialized into the new `Token` class.

2. **Resource Owner Password Credentials Grant**

   ```csharp
   public async Task<Token> GetTokenWithResourceOwnerPasswordCredentialsAsync(string realm,
                                                                              string clientId,
                                                                              string username,
                                                                              string password,
                                                                              string clientSecret,
                                                                              CancellationToken cancellationToken = default)
   {
       var parameters = new Dictionary<string, string>
       {
           { "grant_type", "password" },
           { "client_id", clientId },
           { "client_secret", clientSecret },
           { "username", username },
           { "password", password },
           { "scope", "openid" }
       };

       return await GetBaseUrl(realm)
           .AppendPathSegment($"/realms/{realm}/protocol/openid-connect/token")
           .PostUrlEncodedAsync(parameters, cancellationToken: cancellationToken)
           .ReceiveJson<Token>()
           .ConfigureAwait(false);
   }
   ```

   **Explanation:**

   - This method allows obtaining tokens using the Resource Owner Password Credentials grant type.
   - It is useful for scenarios where the application needs to authenticate with a user's credentials directly.

### Usage Examples

#### Impersonating a User

```csharp
var keycloakClient = new KeycloakClient(baseUrl, adminUsername, adminPassword);

// Impersonate user by ID
var token = await keycloakClient.GetTokenExchangeResponseAsync(
    realm: "myrealm",
    clientId: "myclient",
    userId: "user-id-to-impersonate",
    clientSecret: "client-secret"
);

// Use the access token to perform actions on behalf of the user
string accessToken = token.AccessToken;
```

#### Authenticating with User Credentials

```csharp
var token = await keycloakClient.GetTokenWithResourceOwnerPasswordCredentialsAsync(
    realm: "myrealm",
    clientId: "myclient",
    username: "user@example.com",
    password: "userpassword",
    clientSecret: "client-secret"
);

// Access token for the user
string accessToken = token.AccessToken;
```

## Handling Token Exchange in Applications

When performing impersonation, it's essential to manage user sessions and authentication cookies appropriately.

### Impersonating a User in a Controller

```csharp
public class AccountController : Controller
{
    private readonly KeycloakClient _keycloakClient;

    public AccountController(KeycloakClient keycloakClient)
    {
        _keycloakClient = keycloakClient;
    }

    [Authorize(Roles = "admin")]
    public async Task<IActionResult> Impersonate(string userId)
    {
        var token = await _keycloakClient.GetTokenExchangeResponseAsync(
            realm: "myrealm",
            clientId: "myclient",
            userId: userId,
            clientSecret: "client-secret"
        );

        var handler = new JwtSecurityTokenHandler();
        var jwtToken = handler.ReadJwtToken(token.AccessToken);

        var claims = jwtToken.Claims.ToList();
        claims.Add(new Claim("impersonated", "true"));
        claims.Add(new Claim("id_token", token.IdToken));

        var identity = new ClaimsIdentity(
            claims,
            CookieAuthenticationDefaults.AuthenticationScheme,
            "preferred_username",
            "roles"
        );

        var principal = new ClaimsPrincipal(identity);

        await HttpContext.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, principal);

        return RedirectToAction("Index", "Home");
    }
}
```

The new methods have been tested against a Keycloak instance with token exchange enabled, verifying that tokens are correctly exchanged and received.
