### PR TITLE
added briefRepresentation in query params to show or not the role attributes

### DIFF
--- a/src/Keycloak.Net.Core/Roles/KeycloakClient.cs
+++ b/src/Keycloak.Net.Core/Roles/KeycloakClient.cs
@@ -192,6 +192,7 @@ public partial class KeycloakClient
 	}
 
 	public async Task<IEnumerable<Role>> GetRolesAsync(string realm,
+													   bool briefRepresentation = true,
 													   int? first = null,
 													   int? max = null,
 													   string? search = null,
@@ -201,7 +202,8 @@ public partial class KeycloakClient
 						  {
 							  [nameof(first)] = first,
 							  [nameof(max)] = max,
-							  [nameof(search)] = search
+							  [nameof(search)] = search,
+							  [nameof(briefRepresentation)] = briefRepresentation
 						  };
 
 		return await GetBaseUrl(realm).AppendPathSegment($"/admin/realms/{realm}/roles")


### PR DESCRIPTION
Update the implementation of the Get User Roles by adding the briefRepresentation in queryParams, so that we have the option to get attributes of the role (briefRepresentation = false).
https://www.keycloak.org/docs-api/22.0.1/rest-api/index.html#_users:~:text=GET%20/admin/realms/%7Brealm%7D/roles