### PR TITLE
Added missing "DefaultRole" field to Realm representation class

### DIFF
--- a/src/Keycloak.Net.Core/Models/RealmsAdmin/Realm.cs
+++ b/src/Keycloak.Net.Core/Models/RealmsAdmin/Realm.cs
@@ -1,4 +1,5 @@
 ﻿using Keycloak.Net.Models.Organizations;
+using Keycloak.Net.Models.Roles;
 
 namespace Keycloak.Net.Models.RealmsAdmin;
 
@@ -79,8 +80,10 @@ public class Realm
 	public int? MaxDeltaTimeSeconds { get; set; }
 	[JsonPropertyName("failureFactor")]
 	public int? FailureFactor { get; set; }
+	[JsonPropertyName("defaultRole")]
+	public Role? DefaultRole { get; set;}
 	[JsonPropertyName("defaultRoles")]
-	public IEnumerable<string> DefaultRoles { get; set; }
+	public IEnumerable<string>? DefaultRoles { get; set; }
 	[JsonPropertyName("requiredCredentials")]
 	public IEnumerable<string> RequiredCredentials { get; set; }
 	[JsonPropertyName("otpPolicyType")]


### PR DESCRIPTION
Hi everyone of the nice people supporting this fork, I found out recently that models in this project are out-of-date with the actual [Keycloak API](https://www.keycloak.org/docs-api/latest/rest-api/index.html#RealmRepresentation) and took a liberty to add a field that we urgently need. Could you please merge this? 

And since we are here - are these classes generated automatically by something or is it all written by hand? If it's the former case, maybe it's better to regenerate all classes then?