### PR TITLE
Add cross-realm token exchange methods

### DIFF
--- a/src/Keycloak.Net.Core/Clients/KeycloakClient.cs
+++ b/src/Keycloak.Net.Core/Clients/KeycloakClient.cs
@@ -403,6 +403,58 @@ public partial class KeycloakClient
             .ConfigureAwait(false);
     }
 
+    public async Task<Token> ExchangeExternalTokenAsync(string realm,
+                                                        string clientId,
+                                                        string clientSecret,
+                                                        string subjectToken,
+                                                        string subjectIssuer,
+                                                        CancellationToken cancellationToken = default)
+    {
+        var parameters = new Dictionary<string, string>
+		{
+			{ "grant_type", "urn:ietf:params:oauth:grant-type:token-exchange" },
+			{ "client_id", clientId },
+			{ "client_secret", clientSecret },
+			{ "subject_token", subjectToken },
+			{ "subject_token_type", "urn:ietf:params:oauth:token-type:access_token" },
+			{ "subject_issuer", subjectIssuer },
+			{ "requested_token_type", "urn:ietf:params:oauth:token-type:access_token" }
+		};
+
+        return await GetBaseUrl(realm)
+            .AppendPathSegment($"/realms/{realm}/protocol/openid-connect/token")
+            .PostUrlEncodedAsync(parameters, cancellationToken: cancellationToken)
+            .ReceiveJson<Token>()
+            .ConfigureAwait(false);
+    }
+
+    public async Task<Token> ExchangeTokenForSubjectAsync(string realm,
+                                                          string clientId,
+                                                          string clientSecret,
+                                                          string subjectToken,
+                                                          string requestedSubject,
+                                                          string audience,
+                                                          CancellationToken cancellationToken = default)
+    {
+        var parameters = new Dictionary<string, string>
+		{
+			{ "grant_type", "urn:ietf:params:oauth:grant-type:token-exchange" },
+			{ "client_id", clientId },
+			{ "client_secret", clientSecret },
+			{ "subject_token", subjectToken },
+			{ "subject_token_type", "urn:ietf:params:oauth:token-type:access_token" },
+			{ "requested_token_type", "urn:ietf:params:oauth:token-type:access_token" },
+			{ "requested_subject", requestedSubject },
+			{ "audience", audience }
+		};
+
+        return await GetBaseUrl(realm)
+            .AppendPathSegment($"/realms/{realm}/protocol/openid-connect/token")
+            .PostUrlEncodedAsync(parameters, cancellationToken: cancellationToken)
+            .ReceiveJson<Token>()
+            .ConfigureAwait(false);
+    }
+
     public async Task<Token> GetTokenWithResourceOwnerPasswordCredentialsAsync(string realm,
 																			   string clientId,
 																			   string username,


### PR DESCRIPTION
### Problem

`GetTokenExchangeResponseAsync` sends only `requested_subject` and hardcodes `scope=openid`. That covers impersonation by the calling client's own service account **within a single realm**, but it cannot carry an identity from one realm into another, because `subject_token`, `subject_issuer` and `audience` are never sent.

### Change

Adds the two calls RFC 8693 needs for cross-realm exchange:

- **`ExchangeExternalTokenAsync`** — brokers a token issued by another realm or identity provider into the target realm, via the `subject_issuer` identity-provider alias.
- **`ExchangeTokenForSubjectAsync`** — exchanges that token for one acting as `requested_subject` and issued for `audience`.

### Why two calls and not one

Keycloak requires these as separate steps. A single call carrying both `subject_issuer` and `requested_subject` returns from the external-token branch **before** `requested_subject` is read, and yields a token for the caller instead of for the requested subject — see [keycloak/keycloak#38184](https://github.com/keycloak/keycloak/issues/38184).

### Notes

- Both methods follow the conventions of the surrounding token-endpoint methods and reuse the existing `Token` model, so no new public types are introduced.
- `GetTokenExchangeResponseAsync` is left untouched — this is purely additive.
- Placed next to `GetTokenExchangeResponseAsync` so the token-exchange methods stay together.
- Verified against Keycloak 26 on a live deployment, using an implementation identical to this one.